### PR TITLE
Configure traefik for traffic to home.madtech.cx services

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Traefik was chosen as main loadbalancer and ingress service and is hardcoded to 
 - [ ] add Raspberry Pi's to k8s cluster
 - [x] add MetalLB
 - [x] add traefik
-- [ ] configure traefik for *.home.madtech.cx on NUC
+- [x] configure traefik for *.home.madtech.cx on NUC
 - [ ] switch from Caddy to Traefik for other services
 - [ ] NUC either added to k8s cluster or remove proxmox, install VM directly on hardware to run Ansible/Terraform/bootstrap code and Home Assistant and Jellyfin
 - [ ] create new git repo with local AMT Console changes

--- a/README.md
+++ b/README.md
@@ -115,12 +115,13 @@ Traefik was chosen as main loadbalancer and ingress service and is hardcoded to 
 - [x] use talhelper to configure Talos nodes declaratively
 - [ ] find a way to configure MikroTik router declaratively
 - [ ] migrate software from docker-compose to k8s
-- [x] implement ArgoCD
+- [x] add ArgoCD
 - [ ] experiment with FluxCD
 - [ ] add LTE backup to MikroTik router
 - [ ] add Raspberry Pi's to k8s cluster
-- [x] implement MetalLB
-- [ ] implement traefik
+- [x] add MetalLB
+- [x] add traefik
+- [ ] configure traefik for *.home.madtech.cx on NUC
 - [ ] switch from Caddy to Traefik for other services
 - [ ] NUC either added to k8s cluster or remove proxmox, install VM directly on hardware to run Ansible/Terraform/bootstrap code and Home Assistant and Jellyfin
 - [ ] create new git repo with local AMT Console changes

--- a/argocd/apps/templates/traefik.yaml
+++ b/argocd/apps/templates/traefik.yaml
@@ -6,9 +6,9 @@ metadata:
 spec:
   project: default
   source:
-    chart: traefik
-    repoURL: https://traefik.github.io/charts
-    targetRevision: 34.5.0
+    repoURL: https://github.com/madeddie/homelab.git
+    path: helmcharts/traefik
+    targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
     namespace: traefik

--- a/helmcharts/traefik/Chart.yaml
+++ b/helmcharts/traefik/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: traefik
+version: 0.0.1
+dependencies:
+  - name: traefik
+    repository: https://traefik.github.io/charts
+    version: 34.5.0

--- a/helmcharts/traefik/templates/home_madtech_cx_external.yaml
+++ b/helmcharts/traefik/templates/home_madtech_cx_external.yaml
@@ -1,0 +1,30 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: home-madtech
+  namespace: traefik
+spec:
+  type: ExternalName
+  ports:
+    - name: https
+      port: 443
+      targetPort: 443
+  externalName: home.madtech.cx
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: home-madtech
+  namespace: traefik
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`home.madtech.cx`) || Host(`assistant.home.madtech.cx`) || Host(`jellyfin.home.madtech.cx`)
+      kind: Rule
+      services:
+        - name: home-madtech
+          kind: Service
+          port: 443
+  tls:
+    certResolver: letsencrypt

--- a/helmcharts/traefik/values.yaml
+++ b/helmcharts/traefik/values.yaml
@@ -1,0 +1,21 @@
+traefik:
+  ingressRoute.dashboard.enabled: true
+  service.spec.loadBalancerIP: 192.168.0.240
+  providers:
+    kubernetesCRD:
+      allowExternalNameServices: true
+    kubernetesIngress:
+      allowExternalNameServices: true
+  certificatesResolvers:
+    letsencrypt:
+      acme:
+        email: edwin@madtech.cx
+        storage: /data/acme.json
+        httpChallenge:
+          entryPoint: web
+  persistence:
+    enabled: true
+    storageClass: local-path
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: traefik


### PR DESCRIPTION
home.madtech.cx services are currently running on a NUC managed by docker-compose and hosted behind Caddy.

The router port-forward points to Caddy, but can now point to Traefik.